### PR TITLE
added jupyterlab

### DIFF
--- a/images/sd2e/Dockerfile
+++ b/images/sd2e/Dockerfile
@@ -141,4 +141,7 @@ RUN chown -R jupyter:${NB_GROUP} /home/jupyter && \
 	find /home/jupyter -type f -exec chmod 666 {} \; && \
 	find /home/jupyter -type d -exec chmod 777 {} \;
 
+RUN conda install -c conda-forge jupyterlab
+RUN jupyter labextension install @jupyterlab/hub-extension
+
 USER jupyter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Added Jupyter Lab 
<!--- Describe your changes in detail -->
The hub will function the same way, and default to the usual 'notebook' view will be the default view. However, if the user goes to /user/<username>/lab instead of /user/<username>/tree (the default) they will be brought to the jupyter lab view. 

This has been tested in staging. 
