### PR TITLE
Update singularity image

### DIFF
--- a/images/sd2e/Dockerfile
+++ b/images/sd2e/Dockerfile
@@ -131,6 +131,13 @@ RUN cd examples && \
 ENV MKL_THREADING_LAYER=GNU
 
 ###############################################
+# Install Jupyterlab
+###############################################
+RUN conda install -c conda-forge jupyterlab && \
+    jupyter labextension install @jupyterlab/hub-extension && \
+    docker-clean
+
+###############################################
 # Permissions
 ###############################################
 
@@ -140,8 +147,5 @@ RUN chown -R jupyter:${NB_GROUP} /home/jupyter && \
 	chmod 777 /home/jupyter && \
 	find /home/jupyter -type f -exec chmod 666 {} \; && \
 	find /home/jupyter -type d -exec chmod 777 {} \;
-
-RUN conda install -c conda-forge jupyterlab
-RUN jupyter labextension install @jupyterlab/hub-extension
 
 USER jupyter

--- a/images/singularity/Dockerfile
+++ b/images/singularity/Dockerfile
@@ -1,7 +1,7 @@
 #Image: sd2e/jupyteruser-singularity
-#Version: 0.1.0
+#Version: 0.1.1
 
-FROM sd2e/jupyteruser-sd2e:0.3.1
+FROM sd2e/jupyteruser-sd2e:0.3.6
 
 # Image release
 USER root
@@ -16,7 +16,7 @@ RUN [ ! -e $SD2E_DIR ] && mkdir -p $SD2E_HOME && \
 ##########################################
 # Archive HOME
 ##########################################
-cp -r examples SD2E_README.md $SD2E_HOME/ && \
+cp -r examples SD2E_README.ipynb $SD2E_HOME/ && \
 #cp -r .cache $SD2E_HOME/ && \
 tar -czf $SD2E_DIR/home_archive.tar.gz -C $SD2E_DIR jupyter && \
 chmod 644 $SD2E_DIR/home_archive.tar.gz && \
@@ -37,14 +37,21 @@ COPY enter_singularity.sh /bin/enter_singularity.sh
 RUN chmod 755 /bin/enter_singularity.sh
 #ENTRYPOINT ["/bin/bash"]
 #CMD ["/bin/enter_singularity.sh"]
+ENTRYPOINT ["tini", "--", "/bin/enter_singularity.sh"]
 ##########################################
 # Clean up ENV
 ##########################################
 ENV NB_USER=
 ENV NB_UID=
 ENV NB_GID=
-#ENV HOME=
-#ENV USER=
+ENV NB_GROUP=
+ENV USER=
+ENV HOME='$STOCKYARD/jupyter'
+ENV PYTHONUSERBASE='$STOCKYARD/jupyter_packages'
+ENV JUPYTER_PATH='$STOCKYARD/jupyter_packages/share/jupyter:'
+ENV JUPYTER_WORK='$STOCKYARD/jupyter_packages'
+ENV LOCAL_ENVS='$STOCKYARD/jupyter_packages/envs'
+ENV CONDA_ENVS_PATH='$STOCKYARD/jupyter_packages/envs:'
 #ENV XDG_CACHE_HOME=
 #ENV WORK=
 

--- a/images/singularity/enter_singularity.sh
+++ b/images/singularity/enter_singularity.sh
@@ -22,6 +22,17 @@ if [ -n "$STOCKYARD" ]; then
 	cd $STOCKYARD/jupyter
 fi
 
+# Create work and project data symlinks if they don't exist in $STOCKYARD/jupyter
+if [ ! -e "$STOCKYARD/jupyter/tacc-work" ]; then
+	echo "Creating symlink for tacc-work"
+	ln -s ../ $STOCKYARD/jupyter/tacc-work
+fi
+
+if [ ! -e "$STOCKYARD/jupyter/sd2e-community" ]; then
+	echo "Creating symlink for sd2e-community"
+	ln -s /work/projects/SD2E-Community/prod/data/ $STOCKYARD/jupyter/sd2e-community
+fi
+
 # Delete any legacy configs
 if [ -e $HOME/.jupyter ]; then
 	rm -rf $HOME/.jupyter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update singularity image.

## Description
<!--- Describe your changes in detail -->
This brings the HPC notebook image in sync with the Jupyter Hub notebook image. The singularity image used by the Agave app can now be pulled straight from Docker hub (sd2e/jupyteruser-singularity).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/SD2E/jupyteruser-sd2e/blob/master/CONTRIBUTING.md))
To keep the Jupyter notebook images in sync.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally and on Maverick.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/SD2E/jupyteruser-sd2e/blob/master/CONTRIBUTING.md) guide
